### PR TITLE
fix(docker): override the working directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
       LARAVEL_SAIL: 1
       XDEBUG_MODE: "${SAIL_XDEBUG_MODE:-off}"
       XDEBUG_CONFIG: "${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}"
+    working_dir: /var/www/html/website
     volumes:
-      - ".:/var/www/html"
+      - ".:/var/www/html/website"
     networks:
       - sail
     depends_on:


### PR DESCRIPTION
This will prevent the npm to change the `name` of `package-lock.json`.