### PR TITLE
Fix mount path error when runs the app in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       LARAVEL_SAIL: 1
       XDEBUG_MODE: "${SAIL_XDEBUG_MODE:-off}"
       XDEBUG_CONFIG: "${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}"
-    working_dir: /var/www/html/website
+    working_dir: /var/www/html
     volumes:
-      - ".:/var/www/html/website"
+      - ".:/var/www/html"
     networks:
       - sail
     depends_on:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "website",
             "dependencies": {
                 "@emotion/react": "^11.10.5",
                 "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "website",
     "private": true,
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
- Change the mount path back to `/var/www/html`.
- Define the `name` property in `package.json`, so npm will not change it in `package-lock.json`.