### PR TITLE
Replace alert in auth pages with `notistack`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "axios": "^1.1.3",
                 "laravel-vite-plugin": "^0.6.1",
                 "lodash": "^4.17.21",
+                "notistack": "^2.0.8",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "tailwindcss": "^3.2.1",
@@ -4596,6 +4597,34 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/notistack": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+            "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
+            "dependencies": {
+                "clsx": "^1.1.0",
+                "hoist-non-react-statics": "^3.3.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/notistack"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "@mui/material": "^5.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
             }
         },
         "node_modules/nprogress": {
@@ -9404,6 +9433,15 @@
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
             "dev": true
+        },
+        "notistack": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/notistack/-/notistack-2.0.8.tgz",
+            "integrity": "sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==",
+            "requires": {
+                "clsx": "^1.1.0",
+                "hoist-non-react-statics": "^3.3.0"
+            }
         },
         "nprogress": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "axios": "^1.1.3",
         "laravel-vite-plugin": "^0.6.1",
         "lodash": "^4.17.21",
+        "notistack": "^2.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "tailwindcss": "^3.2.1",

--- a/resources/scripts/Components/DismissSnackbarAction.tsx
+++ b/resources/scripts/Components/DismissSnackbarAction.tsx
@@ -1,0 +1,21 @@
+import Close from '@mui/icons-material/Close';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { SnackbarKey, useSnackbar } from 'notistack';
+import * as React from 'react';
+
+export default function DismissSnackbarAction(key?: SnackbarKey) {
+  const { closeSnackbar } = useSnackbar();
+
+  return (
+    <Tooltip title="Dismiss" arrow>
+      <IconButton
+        color="inherit"
+        size="small"
+        onClick={() => closeSnackbar(key)}
+      >
+        <Close fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/resources/scripts/Pages/Auth/ForgotPassword.tsx
+++ b/resources/scripts/Pages/Auth/ForgotPassword.tsx
@@ -1,9 +1,11 @@
 import AppHead from '@/Components/AppHead';
+import DismissSnackbarAction from '@/Components/DismissSnackbarAction';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { useForm } from '@inertiajs/inertia-react';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import route from 'ziggy-js';
 
@@ -26,6 +28,19 @@ export default function ForgotPassword({ status }: TPropsForgotPassword) {
     e.preventDefault();
     post(route('password.email'));
   };
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  // Display a notification if the reset password email has been sent.
+  React.useEffect(() => {
+    if (status) {
+      enqueueSnackbar(status, {
+        variant: 'success',
+        action: DismissSnackbarAction,
+        preventDuplicate: true,
+      });
+    }
+  }, [status]);
 
   return (
     <GuestLayout>
@@ -50,13 +65,6 @@ export default function ForgotPassword({ status }: TPropsForgotPassword) {
         Just let us know your email address and we will email you a password
         reset link that will allow you to choose a new one.
       </Typography>
-
-      {status
-        && (
-          <div className="mb-4 font-medium text-sm text-green-600">
-            {status}
-          </div>
-        )}
 
       <form onSubmit={submit}>
         <TextField

--- a/resources/scripts/Pages/Auth/Login.tsx
+++ b/resources/scripts/Pages/Auth/Login.tsx
@@ -1,4 +1,5 @@
 import AppHead from '@/Components/AppHead';
+import DismissSnackbarAction from '@/Components/DismissSnackbarAction';
 import Link from '@/Components/Link';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { useForm } from '@inertiajs/inertia-react';
@@ -7,6 +8,7 @@ import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import route from 'ziggy-js';
 
@@ -42,18 +44,24 @@ export default function Login({ status, canResetPassword }: TPropsLogin) {
     post(route('login'));
   };
 
+  const { enqueueSnackbar } = useSnackbar();
+
+  React.useEffect(() => {
+    if (status) {
+      enqueueSnackbar(status, {
+        variant: 'success',
+        action: DismissSnackbarAction,
+        preventDuplicate: true,
+      });
+    }
+  }, [status]);
+
   return (
     <GuestLayout>
       <AppHead
         title="Masuk"
         description="Masuk ke akun Tokukas Anda untuk mulai bertransaksi."
       />
-
-      {status && (
-        <div className="mb-4 font-medium text-sm text-green-600">
-          {status}
-        </div>
-      )}
 
       <form onSubmit={submit}>
         <TextField

--- a/resources/scripts/Pages/Auth/VerifyEmail.tsx
+++ b/resources/scripts/Pages/Auth/VerifyEmail.tsx
@@ -1,13 +1,11 @@
 import AppHead from '@/Components/AppHead';
+import DismissSnackbarAction from '@/Components/DismissSnackbarAction';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { useForm } from '@inertiajs/inertia-react';
-import Close from '@mui/icons-material/Close';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { SnackbarKey, useSnackbar } from 'notistack';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import route from 'ziggy-js';
 
@@ -17,19 +15,7 @@ type TPropsVerifyEmail = {
 
 export default function VerifyEmail({ status }: TPropsVerifyEmail) {
   const { post, processing } = useForm();
-  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
-
-  const dismissSnackbarAction = (id: SnackbarKey) => (
-    <Tooltip title="Dismiss" arrow>
-      <IconButton
-        color="inherit"
-        size="small"
-        onClick={() => closeSnackbar(id)}
-      >
-        <Close fontSize="small" />
-      </IconButton>
-    </Tooltip>
-  );
+  const { enqueueSnackbar } = useSnackbar();
 
   // Display a notification to the user if the resend verification email was successful.
   React.useEffect(() => {
@@ -39,7 +25,7 @@ export default function VerifyEmail({ status }: TPropsVerifyEmail) {
           provided during registration.`,
         {
           variant: 'success',
-          action: dismissSnackbarAction,
+          action: DismissSnackbarAction,
           preventDuplicate: true,
         },
       );

--- a/resources/scripts/Pages/Auth/VerifyEmail.tsx
+++ b/resources/scripts/Pages/Auth/VerifyEmail.tsx
@@ -1,11 +1,15 @@
-import * as React from 'react';
+import AppHead from '@/Components/AppHead';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { useForm } from '@inertiajs/inertia-react';
-import route from 'ziggy-js';
-import AppHead from '@/Components/AppHead';
-import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
+import Close from '@mui/icons-material/Close';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { SnackbarKey, useSnackbar } from 'notistack';
+import * as React from 'react';
+import route from 'ziggy-js';
 
 type TPropsVerifyEmail = {
   status: string;
@@ -13,6 +17,34 @@ type TPropsVerifyEmail = {
 
 export default function VerifyEmail({ status }: TPropsVerifyEmail) {
   const { post, processing } = useForm();
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+  const dismissSnackbarAction = (id: SnackbarKey) => (
+    <Tooltip title="Dismiss" arrow>
+      <IconButton
+        color="inherit"
+        size="small"
+        onClick={() => closeSnackbar(id)}
+      >
+        <Close fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+
+  // Display a notification to the user if the resend verification email was successful.
+  React.useEffect(() => {
+    if (status === 'verification-link-sent') {
+      enqueueSnackbar(
+        `A new verification link has been sent to the email address you
+          provided during registration.`,
+        {
+          variant: 'success',
+          action: dismissSnackbarAction,
+          preventDuplicate: true,
+        },
+      );
+    }
+  }, [status]);
 
   return (
     <GuestLayout>
@@ -35,13 +67,6 @@ export default function VerifyEmail({ status }: TPropsVerifyEmail) {
         on the link we just emailed to you? If you didn&apos;t receive the
         email, we will gladly send you another.
       </Typography>
-
-      {status === 'verification-link-sent' && (
-        <div className="mb-4 font-medium text-sm text-green-600">
-          A new verification link has been sent to the email address you
-          provided during registration.
-        </div>
-      )}
 
       <Box
         sx={{

--- a/resources/scripts/app.tsx
+++ b/resources/scripts/app.tsx
@@ -11,6 +11,7 @@ import { StyledEngineProvider } from '@mui/material';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { SnackbarProvider } from 'notistack';
 import AppConfig from './Config/App';
 import ThemeLayout from './Layouts/ThemeLayout';
 
@@ -33,10 +34,12 @@ const appName = AppConfig.name;
       root.render(
         <React.StrictMode>
           <StyledEngineProvider injectFirst>
-            <ThemeLayout>
-              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-              <App {...props} />
-            </ThemeLayout>
+            <SnackbarProvider>
+              <ThemeLayout>
+                {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+                <App {...props} />
+              </ThemeLayout>
+            </SnackbarProvider>
           </StyledEngineProvider>
         </React.StrictMode>,
       );


### PR DESCRIPTION
## Changes Made

This pull request **replaces the alert notifications** on all authentication pages with `Snackbar` components generated using the `notistack` library. 

Additionally, a new component called **`DismissSnackbarAction`** has been added to allow users to dismiss `Snackbar` notifications. 

## Related Issues or Pull Requests

None
