### PR TITLE
Fix `MenuItemLink` component

### DIFF
--- a/resources/scripts/Components/Link.tsx
+++ b/resources/scripts/Components/Link.tsx
@@ -1,4 +1,4 @@
-import { Link as InertiaLink } from '@inertiajs/inertia-react';
+import { InertiaLink } from '@inertiajs/inertia-react';
 import MuiLink, { LinkProps } from '@mui/material/Link';
 import * as React from 'react';
 

--- a/resources/scripts/Components/MenuItemLink.tsx
+++ b/resources/scripts/Components/MenuItemLink.tsx
@@ -17,7 +17,6 @@ export default function MenuItemLink({
   return (
     <MenuItem
       component={Link}
-      ref={Link}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >

--- a/resources/scripts/Components/Navbar.tsx
+++ b/resources/scripts/Components/Navbar.tsx
@@ -34,7 +34,7 @@ type TMenuItem = {
   name: string;
   icon?: React.ReactNode;
   href?: string;
-  onClick?: () => void;
+  onClick?: (e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
 const MENU_ITEM_DIVIDER = 'DIVIDER';
@@ -95,7 +95,12 @@ export default function Navbar() {
         {
           name: 'Logout',
           icon: <LogoutIcon fontSize="small" />,
-          onClick: () => post(route('logout')),
+          onClick: (e) => {
+            if (e) {
+              e.preventDefault();
+            }
+            post(route('logout'));
+          },
         },
       ] : [
         {
@@ -255,9 +260,9 @@ export default function Navbar() {
                   <MenuItemLink
                     key={menu.name}
                     href={menu.href}
-                    onClick={() => {
+                    onClick={(e) => {
                       if (menu.onClick) {
-                        menu.onClick();
+                        menu.onClick(e);
                       }
                       handleCloseUserMenu();
                     }}

--- a/resources/scripts/Components/Navbar.tsx
+++ b/resources/scripts/Components/Navbar.tsx
@@ -28,13 +28,13 @@ import * as React from 'react';
 import route from 'ziggy-js';
 import BrandLogo from './BrandLogo';
 import Link from './Link';
-import MenuItemLink from './MenuItemLink';
+import MenuItemLink, { TPropsMenuItemLink } from './MenuItemLink';
 
-type TMenuItem = {
+type TMenuItem = TPropsMenuItemLink & {
+  /** The name of menu item. */
   name: string;
+  /** The icon of menu item. */
   icon?: React.ReactNode;
-  href?: string;
-  onClick?: (e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
 };
 
 const MENU_ITEM_DIVIDER = 'DIVIDER';
@@ -66,15 +66,15 @@ export default function Navbar() {
   const { colorMode, toggleColorMode } = React.useContext(ColorModeContext);
 
   React.useEffect(() => {
-    const divider = {
+    const divider: TMenuItem = {
       name: MENU_ITEM_DIVIDER,
     };
-    const settingsMenu = {
+    const settingsMenu: TMenuItem = {
       name: 'Settings',
       href: route('settings'),
       icon: <SettingsIcon fontSize="small" />,
     };
-    const themeMenu = {
+    const themeMenu: TMenuItem = {
       name: colorMode === 'light' ? 'Dark Mode' : 'Light Mode',
       icon: colorMode === 'light'
         ? <Brightness4Icon fontSize="small" />
@@ -258,6 +258,8 @@ export default function Navbar() {
                 }
                 return (
                   <MenuItemLink
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...menu}
                     key={menu.name}
                     href={menu.href}
                     onClick={(e) => {
@@ -267,13 +269,13 @@ export default function Navbar() {
                       handleCloseUserMenu();
                     }}
                   >
-                    {
-                      menu.icon && (
-                        <ListItemIcon>{menu.icon}</ListItemIcon>
-                      )
-                    }
-                    <ListItemText>
-                      {' '}
+                    {menu.icon && (
+                      <ListItemIcon>{menu.icon}</ListItemIcon>
+                    )}
+                    <ListItemText
+                      inset={!menu.icon
+                        && userMenuItems.some((item) => item.icon)}
+                    >
                       {menu.name}
                     </ListItemText>
                   </MenuItemLink>


### PR DESCRIPTION
## Changes Made

This pull request includes the following updates:

- Improved the `TMenuItem` component by extending the `TPropsMenuItemLink`.
- Added a call to `e.preventDefault()` in the `onClick()` function for the Logout menu item.
- Applied the `inset` prop to the `ListItemText` component.
- Simplified the import statement for the `InertiaLink` component.
- Removed the `ref` property from the `MenuItemLink` component as its purpose was not clear.

## Related Issues or Pull Requests

None